### PR TITLE
modify perf testing acceptance criteria in dev to avoid intermittent failures

### DIFF
--- a/environments/cdp-dev/conf.cfg
+++ b/environments/cdp-dev/conf.cfg
@@ -1,1 +1,3 @@
 # add any environment variables to override the default ones specified in https://github.com/UKHomeOffice/cdp-deployment-templates/blob/master/vars/common.cfg
+PERF_TEST_P90_THRESHOLD=500ms
+PERF_TEST_AVG_THRESHOLD=200ms


### PR DESCRIPTION
Lowered the thresholds as they are arbitrary anyway and the dev environment is a very lightweight one